### PR TITLE
Use user id from headers for user-specific queries instead of passing manually

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/content_service/config/RequestHeaderUserInterceptor.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/config/RequestHeaderUserInterceptor.java
@@ -1,0 +1,24 @@
+package de.unistuttgart.iste.gits.content_service.config;
+
+import de.unistuttgart.iste.gits.common.user_handling.RequestHeaderUserProcessor;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.WebGraphQlRequest;
+import org.springframework.graphql.server.WebGraphQlResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * This class is used to add data from the request headers to the GraphQL context.
+ */
+@Configuration
+public class RequestHeaderUserInterceptor implements WebGraphQlInterceptor {
+    @NotNull
+    @Override
+    @SneakyThrows
+    public Mono<WebGraphQlResponse> intercept(@NotNull WebGraphQlRequest request, @NotNull Chain chain) {
+        RequestHeaderUserProcessor.process(request);
+        return chain.next(request);
+    }
+}

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
@@ -1,14 +1,12 @@
 package de.unistuttgart.iste.gits.content_service.controller;
 
+import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import de.unistuttgart.iste.gits.content_service.service.ContentService;
 import de.unistuttgart.iste.gits.content_service.service.UserProgressDataService;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
-import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
@@ -38,13 +36,8 @@ public class ContentController {
     }
 
     @SchemaMapping(typeName = "MediaContent", field = "userProgressData")
-    public UserProgressData userProgressData(MediaContent content, @Argument UUID userId) {
-        return userProgressDataService.getUserProgressData(userId, content.getId());
-    }
-
-    @SchemaMapping(typeName = "Assessment", field = "userProgressData")
-    public UserProgressData userProgressData(Assessment content, @Argument UUID userId) {
-        return userProgressDataService.getUserProgressData(userId, content.getId());
+    public UserProgressData userProgressData(MediaContent content, @ContextValue LoggedInUser currentUser) {
+        return userProgressDataService.getUserProgressData(currentUser.getId(), content.getId());
     }
 
     @MutationMapping

--- a/src/main/resources/graphql/service/content.graphqls
+++ b/src/main/resources/graphql/service/content.graphqls
@@ -9,11 +9,9 @@ interface Content {
     """
     metadata: ContentMetadata!
     """
-    Progress data of the content, specific to given users.
-    If userId is not provided, the progress data of the current user is returned.
-    If the user has no permission to view the progress data to one or of the provided users, an error is thrown.
+    Progress data of the content for the current user.
     """
-    userProgressData(userId: UUID): UserProgressData!
+    userProgressData: UserProgressData!
 }
 
 type ContentMetadata {
@@ -56,11 +54,9 @@ type MediaContent implements Content {
     metadata: ContentMetadata!
 
     """
-    Progress data of the content, specific to given users.
-    If userId is not provided, the progress data of the current user is returned.
-    If the user has no permission to view the progress data to one or of the provided users, an error is thrown.
+    Progress data of the content for the current user.
     """
-    userProgressData(userId: UUID): UserProgressData!
+    userProgressData: UserProgressData!
 }
 
 interface Assessment implements Content {
@@ -80,11 +76,9 @@ interface Assessment implements Content {
     """
     metadata: ContentMetadata!
     """
-    Progress data of the content, specific to given users.
-    If userId is not provided, the progress data of the current user is returned.
-    If the user has no permission to view the progress data to one or of the provided users, an error is thrown.
+    Progress data of the content for the current user.
     """
-    userProgressData(userId: UUID): UserProgressData!
+    userProgressData: UserProgressData!
 }
 
 type AssessmentMetadata {
@@ -125,11 +119,9 @@ type FlashcardSetAssessment implements Assessment & Content {
     metadata: ContentMetadata!
 
     """
-    Progress data of the content, specific to given users.
-    If userId is not provided, the progress data of the current user is returned.
-    If the user has no permission to view the progress data to one or of the provided users, an error is thrown.
+    Progress data of the content for the current user.
     """
-    userProgressData(userId: UUID): UserProgressData!
+    userProgressData: UserProgressData!
 }
 
 # add more types here


### PR DESCRIPTION
## Description of changes
Uses the new functionality where user data is transmitted via the headers to get the current user id for queries/mutations depending on it.

  
## How has this been tested?
Please describe the test strategy you followed.

- [x] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test

## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
