### PR TITLE
contentsByIds return list of Contents instead of ContentPayload

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
@@ -26,7 +26,7 @@ public class ContentController {
     }
 
     @QueryMapping
-    public ContentPayload contentsByIds(@Argument List<UUID> ids) {
+    public List<Content> contentsByIds(@Argument List<UUID> ids) {
         return contentService.getContentsById(ids);
     }
 

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/service/ContentService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/service/ContentService.java
@@ -72,11 +72,11 @@ public class ContentService {
         }
     }
 
-    public ContentPayload getContentsById(List<UUID> ids) {
-        return createContentPayload(contentRepository.findByIdIn(ids)
+    public List<Content> getContentsById(List<UUID> ids) {
+        return contentRepository.findByIdIn(ids)
                 .stream()
                 .map(contentMapper::entityToDto)
-                .toList());
+                .toList();
     }
 
     public List<List<Content>> getContentsByChapterIds(List<UUID> chapterIds) {

--- a/src/main/resources/graphql/service/query.graphqls
+++ b/src/main/resources/graphql/service/query.graphqls
@@ -6,7 +6,7 @@ type Query {
     """
     get contents by ids
     """
-    contentsByIds(ids: [UUID!]!): ContentPayload!
+    contentsByIds(ids: [UUID!]!): [Content!]!
     """
     get contents by chapter ids. Returns a list containing sublists, where each sublist contains all contents
     associated with that chapter


### PR DESCRIPTION
contentsByIds return a list of `Content`s instead of a `ContentPayload` (pagination etc. not really needed when querying by id)