### PR TITLE
Use gradle docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:experimental
-FROM eclipse-temurin:17-jdk AS build
+FROM gradle:7.6.2-jdk17 AS build
 WORKDIR /workspace/app
 
 COPY . /workspace/app
-RUN ./gradlew clean build -x test
+RUN gradle clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)
 
 FROM eclipse-temurin:17-jdk


### PR DESCRIPTION
Until now, every time each container was built it downloaded gradle because builds were executed using the gradle wrapper. This PR changes the Dockerfile such that instead a docker-image containing gradle is used, which can be re-used between different containers and for subsequent builds. This should speed up build times.