### PR TITLE
add non throwing query for contents by ids

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/controller/ContentController.java
@@ -31,6 +31,11 @@ public class ContentController {
     }
 
     @QueryMapping
+    public List<Content> findContentsByIds(@Argument List<UUID> ids) {
+        return contentService.findContentsById(ids);
+    }
+
+    @QueryMapping
     List<List<Content>> contentsByChapterIds(@Argument List<UUID> chapterIds) {
         return contentService.getContentsByChapterIds(chapterIds);
     }

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/repository/ContentRepository.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/repository/ContentRepository.java
@@ -11,9 +11,6 @@ import java.util.UUID;
 @Repository
 public interface ContentRepository extends JpaRepository<ContentEntity, UUID> {
 
-    @Query("select content from Content content where content.id in (:ids)")
-    List<ContentEntity> findByIdIn(List<UUID> ids);
-
     @Query("select content from Content content where content.metadata.chapterId in (:chapterIds)")
     List<ContentEntity> findByChapterIdIn(List<UUID> chapterIds);
 }

--- a/src/main/resources/graphql/service/query.graphqls
+++ b/src/main/resources/graphql/service/query.graphqls
@@ -4,9 +4,15 @@ type Query {
     """
     contents: ContentPayload!
     """
-    get contents by ids
+    Get contents by ids. Throws an error if any of the ids are not found.
     """
     contentsByIds(ids: [UUID!]!): [Content!]!
+
+    """
+    Get contents by ids. If any of the given ids are not found, the corresponding element in the result list will be null.
+    """
+    findContentsByIds(ids: [UUID!]!): [Content]!
+
     """
     get contents by chapter ids. Returns a list containing sublists, where each sublist contains all contents
     associated with that chapter

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/api/query/QueryByIdTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/api/query/QueryByIdTest.java
@@ -1,0 +1,181 @@
+package de.unistuttgart.iste.gits.content_service.api.query;
+
+import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
+import de.unistuttgart.iste.gits.content_service.TestData;
+import de.unistuttgart.iste.gits.content_service.persistence.dao.ContentEntity;
+import de.unistuttgart.iste.gits.content_service.persistence.repository.ContentRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.test.tester.GraphQlTester;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.hasSize;
+
+@GraphQlApiTest
+class QueryByIdTest {
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    /**
+     * Given valid ids
+     * When the contentsByIds query is called
+     * Then the contents are returned in the same order as the ids
+     */
+    @Test
+    void getByIdOrderIsConsistent(GraphQlTester graphQlTester) {
+        List<ContentEntity> contentEntities = List.of(
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build()),
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build()),
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build())
+        );
+
+        List<UUID> ids = contentEntities.stream()
+                .map(ContentEntity::getId)
+                .toList();
+
+        String query = """
+                query($ids: [UUID!]!) {
+                    contentsByIds(ids: $ids) {
+                        id
+                    }
+                }
+                """;
+
+        graphQlTester.document(query)
+                .variable("ids", ids)
+                .execute()
+                .path("contentsByIds[*].id")
+                .entityList(UUID.class)
+                .containsExactly(ids.toArray(UUID[]::new));
+
+        // test the order is correct
+        List<UUID> idsReordered = List.of(ids.get(2), ids.get(0), ids.get(1));
+
+        graphQlTester.document(query)
+                .variable("ids", idsReordered)
+                .execute()
+                .path("contentsByIds[*].id")
+                .entityList(UUID.class)
+                .containsExactly(idsReordered.toArray(UUID[]::new));
+    }
+
+    /**
+     * Given valid ids
+     * When the findContentsByIds query is called
+     * Then the contents are returned in the same order as the ids
+     */
+    @Test
+    void findByIdOrderIsConsistent(GraphQlTester graphQlTester) {
+        List<ContentEntity> contentEntities = List.of(
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build()),
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build()),
+                contentRepository.save(TestData.dummyMediaContentEntityBuilder().build())
+        );
+
+        List<UUID> ids = contentEntities.stream()
+                .map(ContentEntity::getId)
+                .toList();
+
+        String query = """
+                query($ids: [UUID!]!) {
+                    findContentsByIds(ids: $ids) {
+                        id
+                    }
+                }
+                """;
+
+        graphQlTester.document(query)
+                .variable("ids", ids)
+                .execute()
+                .path("findContentsByIds[*].id")
+                .entityList(UUID.class)
+                .containsExactly(ids.toArray(UUID[]::new));
+
+        // test the order is correct
+        List<UUID> idsReordered = List.of(ids.get(2), ids.get(0), ids.get(1));
+
+        graphQlTester.document(query)
+                .variable("ids", idsReordered)
+                .execute()
+                .path("findContentsByIds[*].id")
+                .entityList(UUID.class)
+                .containsExactly(idsReordered.toArray(UUID[]::new));
+    }
+
+    /**
+     * Given some ids of non-existing contents
+     * When the contentsByIds query is called
+     * Then an error is returned containing the ids of the non-existing contents
+     */
+    @Test
+    void getByNonExistingIds(GraphQlTester graphQlTester) {
+        ContentEntity existingContentEntity = contentRepository.save(TestData.dummyMediaContentEntityBuilder().build());
+
+        List<UUID> ids = List.of(
+                existingContentEntity.getId(),
+                UUID.randomUUID(),
+                UUID.randomUUID()
+        );
+
+        String query = """
+                query($ids: [UUID!]!) {
+                    contentsByIds(ids: $ids) {
+                        id
+                    }
+                }
+                """;
+
+        graphQlTester.document(query)
+                .variable("ids", ids)
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    String errorMessage = errors.get(0).getMessage();
+                    assertThat(errorMessage, containsStringIgnoringCase("Contents with ids"));
+                    assertThat(errorMessage, containsStringIgnoringCase(ids.get(1).toString()));
+                    assertThat(errorMessage, containsStringIgnoringCase(ids.get(2).toString()));
+                    assertThat(errorMessage, containsStringIgnoringCase("not found"));
+                });
+    }
+
+    /**
+     * Given some ids of non-existing contents
+     * When the findContentsByIds query is called
+     * Then the contents are returned in the same order as the ids and null is used for the non-existing contents
+     */
+    @Test
+    void findByNonExistingIds(GraphQlTester graphQlTester) {
+        ContentEntity existingContentEntity = contentRepository.save(TestData.dummyMediaContentEntityBuilder().build());
+
+        List<UUID> ids = List.of(
+                existingContentEntity.getId(),
+                UUID.randomUUID(),
+                UUID.randomUUID()
+        );
+
+        String query = """
+                query($ids: [UUID!]!) {
+                    findContentsByIds(ids: $ids) {
+                        id
+                    }
+                }
+                """;
+
+        graphQlTester.document(query)
+                .variable("ids", ids)
+                .execute()
+                .path("findContentsByIds")
+                .entityList(ContentEntity.class).containsExactly(
+                        ContentEntity.builder().id(existingContentEntity.getId()).build(),
+                        null,
+                        null
+                );
+    }
+
+}


### PR DESCRIPTION
## Description of changes
When a reward log item has an associated content id, which was later deleted in the content service, the query throws an error because the corresponding content obviously can no longer be fetched. 
To fix this, I added a non-throwing query for retrieving contents by ids. I followed the Spring naming schema and called it "findContentsByIds". It will just use null for contents it cannot find.
Additionally, the "contentsById" query would just return a smaller list if it could not find a particular content. It would not even throw an error. I fixed this behaviour and made it consistent with course service queries.
So now both queries ensure that the order is preserved and the resulting list has the same size than the ids parameter.
  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [x] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test

## Checklist before requesting a review
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
