### PR TITLE
add helper fields to user progress data

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/dao/UserProgressDataEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/dao/UserProgressDataEntity.java
@@ -1,16 +1,10 @@
 package de.unistuttgart.iste.gits.content_service.persistence.dao;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.OrderBy;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Entity(name = "UserProgressData")
 @Data
@@ -31,22 +25,9 @@ public class UserProgressDataEntity {
 
     @ElementCollection
     @OrderBy(clause = "timestamp DESC")
-    private List<ProgressLogItemEmbeddable> progressLog;
+    @Builder.Default
+    private List<ProgressLogItemEmbeddable> progressLog = new ArrayList<>();
 
     @Column(nullable = true)
     private Integer learningInterval;
-
-    public Optional<OffsetDateTime> getLastLearnDate() {
-        return progressLog.stream()
-                .map(ProgressLogItemEmbeddable::getTimestamp)
-                .max(OffsetDateTime::compareTo);
-    }
-
-    public Optional<OffsetDateTime> getNextLearnDate() {
-        if (learningInterval == null) {
-            return Optional.empty();
-        }
-        return getLastLearnDate()
-                .map(lastLearnDate -> lastLearnDate.plusDays(learningInterval));
-    }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/mapper/UserProgressDataMapper.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/mapper/UserProgressDataMapper.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class UserProgressDataMapper {
@@ -15,10 +18,45 @@ public class UserProgressDataMapper {
     private final ModelMapper modelMapper;
 
     public UserProgressData entityToDto(UserProgressDataEntity userProgressDataEntity) {
-        return modelMapper.map(userProgressDataEntity, UserProgressData.class);
+        UserProgressData result = modelMapper.map(userProgressDataEntity, UserProgressData.class);
+
+        Optional<OffsetDateTime> optionalLastLearnDate = getLastLearnDate(userProgressDataEntity);
+        Optional<OffsetDateTime> optionalNextLearnDate = getNextLearnDate(userProgressDataEntity, optionalLastLearnDate);
+
+        result.setLastLearnDate(optionalLastLearnDate.orElse(null));
+        result.setNextLearnDate(optionalNextLearnDate.orElse(null));
+
+        result.setIsLearned(isLearned(userProgressDataEntity));
+        result.setIsDueForReview(isDueForReview(optionalNextLearnDate));
+
+        return result;
     }
 
     public ProgressLogItemEmbeddable eventToEmbeddable(UserProgressLogEvent userProgressLogEvent) {
         return modelMapper.map(userProgressLogEvent, ProgressLogItemEmbeddable.class);
+    }
+
+    private static Boolean isDueForReview(Optional<OffsetDateTime> optionalNextLearnDate) {
+        return optionalNextLearnDate
+                .map(nextReviewDate -> nextReviewDate.isBefore(OffsetDateTime.now()))
+                .orElse(false);
+    }
+
+    private static boolean isLearned(UserProgressDataEntity userProgressDataEntity) {
+        return userProgressDataEntity.getProgressLog().stream()
+                .anyMatch(ProgressLogItemEmbeddable::isSuccess);
+    }
+
+    private static Optional<OffsetDateTime> getNextLearnDate(UserProgressDataEntity userProgressDataEntity, Optional<OffsetDateTime> optionalLastLearnDate) {
+        return userProgressDataEntity.getLearningInterval() == null
+                ? Optional.empty()
+                : optionalLastLearnDate.map(lastLearnDate -> lastLearnDate.plusDays(userProgressDataEntity.getLearningInterval()));
+    }
+
+    private static Optional<OffsetDateTime> getLastLearnDate(UserProgressDataEntity userProgressDataEntity) {
+        return userProgressDataEntity.getProgressLog().stream()
+                .filter(ProgressLogItemEmbeddable::isSuccess)
+                .map(ProgressLogItemEmbeddable::getTimestamp)
+                .max(OffsetDateTime::compareTo);
     }
 }

--- a/src/main/resources/graphql/service/progressData.graphqls
+++ b/src/main/resources/graphql/service/progressData.graphqls
@@ -28,10 +28,18 @@ type UserProgressData {
     """
     nextLearnDate: DateTime
     """
-    The last time the content was learned.
+    The last time the content was learned successfully.
     This is null if the user has not completed the content item once.
     """
     lastLearnDate: DateTime
+    """
+    True if the user has completed the content item at least once successfully.
+    """
+    isLearned: Boolean!
+    """
+    True if the assessment is due for review.
+    """
+    isDueForReview: Boolean!
 }
 
 type ProgressLogItem {

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/api/query/QueryContentsWithUserDataTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/api/query/QueryContentsWithUserDataTest.java
@@ -3,18 +3,14 @@ package de.unistuttgart.iste.gits.content_service.api.query;
 import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.content_service.TestData;
-import de.unistuttgart.iste.gits.content_service.persistence.dao.MediaContentEntity;
-import de.unistuttgart.iste.gits.content_service.persistence.dao.ProgressLogItemEmbeddable;
-import de.unistuttgart.iste.gits.content_service.persistence.dao.UserProgressDataEntity;
+import de.unistuttgart.iste.gits.content_service.persistence.dao.*;
 import de.unistuttgart.iste.gits.content_service.persistence.repository.ContentRepository;
 import de.unistuttgart.iste.gits.content_service.persistence.repository.UserProgressDataRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.util.List;
 import java.util.UUID;
 
@@ -98,6 +94,10 @@ class QueryContentsWithUserDataTest {
                             userProgressData {
                                 userId
                                 learningInterval
+                                lastLearnDate
+                                nextLearnDate
+                                isLearned
+                                isDueForReview
                                 log {
                                     timestamp
                                     success
@@ -119,6 +119,12 @@ class QueryContentsWithUserDataTest {
                 .path("contents.elements[0].metadata.chapterId").entity(UUID.class).isEqualTo(chapterId)
                 .path("contents.elements[0].userProgressData.userId").entity(UUID.class).isEqualTo(userId1)
                 .path("contents.elements[0].userProgressData.learningInterval").entity(Integer.class).isEqualTo(1)
+                .path("contents.elements[0].userProgressData.lastLearnDate").entity(OffsetDateTime.class)
+                .matches(lastLearnDate -> lastLearnDate.isEqual(OffsetDateTime.parse("2021-01-01T00:00:00+01:00")))
+                .path("contents.elements[0].userProgressData.nextLearnDate").entity(OffsetDateTime.class)
+                .matches(nextLearnDate -> nextLearnDate.isEqual(OffsetDateTime.parse("2021-01-02T00:00:00+01:00")))
+                .path("contents.elements[0].userProgressData.isLearned").entity(Boolean.class).isEqualTo(true)
+                .path("contents.elements[0].userProgressData.isDueForReview").entity(Boolean.class).isEqualTo(true)
                 .path("contents.elements[0].userProgressData.log[0].timestamp").entity(OffsetDateTime.class).satisfies(
                         offsetDateTime -> assertThat(
                                 offsetDateTime.isEqual(OffsetDateTime.of(2021, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(1))),

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/mapper/TestUserProgressDataMapper.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/mapper/TestUserProgressDataMapper.java
@@ -1,0 +1,119 @@
+package de.unistuttgart.iste.gits.content_service.mapper;
+
+import de.unistuttgart.iste.gits.content_service.persistence.dao.ProgressLogItemEmbeddable;
+import de.unistuttgart.iste.gits.content_service.persistence.dao.UserProgressDataEntity;
+import de.unistuttgart.iste.gits.content_service.persistence.mapper.UserProgressDataMapper;
+import de.unistuttgart.iste.gits.generated.dto.UserProgressData;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class TestUserProgressDataMapper {
+
+    private UserProgressDataMapper userProgressDataMapper = new UserProgressDataMapper(new ModelMapper());
+
+    @Test
+    void testFullMapping() {
+        UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
+                .userId(UUID.randomUUID())
+                .id(UUID.randomUUID())
+                .contentId(UUID.randomUUID())
+                .learningInterval(2)
+                .progressLog(List.of(
+                        ProgressLogItemEmbeddable.builder()
+                                .correctness(1.0)
+                                .hintsUsed(1)
+                                .success(true)
+                                .timestamp(OffsetDateTime.parse("2021-01-01T00:00:00Z"))
+                                .build()))
+                .build();
+
+        UserProgressData actual = userProgressDataMapper.entityToDto(userProgressDataEntity);
+
+        assertThat(actual.getUserId(), is(userProgressDataEntity.getUserId()));
+        assertThat(actual.getContentId(), is(userProgressDataEntity.getContentId()));
+        assertThat(actual.getLearningInterval(), is(userProgressDataEntity.getLearningInterval()));
+        assertThat(actual.getLog(), contains(
+                allOf(
+                        hasProperty("correctness", is(1.0)),
+                        hasProperty("hintsUsed", is(1)),
+                        hasProperty("success", is(true)),
+                        hasProperty("timestamp", is(OffsetDateTime.parse("2021-01-01T00:00:00Z")))
+                )
+        ));
+        assertThat(actual.getLastLearnDate(), is(OffsetDateTime.parse("2021-01-01T00:00:00Z")));
+        assertThat(actual.getIsLearned(), is(true));
+        assertThat(actual.getNextLearnDate(), is(OffsetDateTime.parse("2021-01-03T00:00:00Z")));
+        assertThat(actual.getIsDueForReview(), is(true));
+    }
+
+    @Test
+    void testContentNotLearnedSuccessful() {
+        UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
+                .userId(UUID.randomUUID())
+                .id(UUID.randomUUID())
+                .contentId(UUID.randomUUID())
+                .learningInterval(2)
+                .progressLog(List.of(
+                        ProgressLogItemEmbeddable.builder()
+                                .correctness(0.0)
+                                .hintsUsed(1)
+                                .success(false)
+                                .timestamp(OffsetDateTime.parse("2021-01-01T00:00:00Z"))
+                                .build()))
+                .build();
+
+        UserProgressData actual = userProgressDataMapper.entityToDto(userProgressDataEntity);
+
+        assertThat(actual.getLastLearnDate(), is(nullValue()));
+        assertThat(actual.getIsLearned(), is(false));
+        assertThat(actual.getNextLearnDate(), is(nullValue()));
+        assertThat(actual.getIsDueForReview(), is(false));
+    }
+
+    @Test
+    void testContentNotLearnedYet() {
+        UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
+                .userId(UUID.randomUUID())
+                .id(UUID.randomUUID())
+                .contentId(UUID.randomUUID())
+                .learningInterval(2).build();
+
+        UserProgressData actual = userProgressDataMapper.entityToDto(userProgressDataEntity);
+
+        assertThat(actual.getLastLearnDate(), is(nullValue()));
+        assertThat(actual.getIsLearned(), is(false));
+        assertThat(actual.getNextLearnDate(), is(nullValue()));
+        assertThat(actual.getIsDueForReview(), is(false));
+    }
+
+    @Test
+    void testContentNotDueForRepetitionYet() {
+        UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
+                .userId(UUID.randomUUID())
+                .id(UUID.randomUUID())
+                .contentId(UUID.randomUUID())
+                .learningInterval(2)
+                .progressLog(List.of(
+                        ProgressLogItemEmbeddable.builder()
+                                .correctness(0.0)
+                                .hintsUsed(1)
+                                .success(true)
+                                .timestamp(OffsetDateTime.now())
+                                .build()))
+                .build();
+
+        UserProgressData actual = userProgressDataMapper.entityToDto(userProgressDataEntity);
+
+        assertThat(actual.getLastLearnDate(), is(not(nullValue())));
+        assertThat(actual.getIsLearned(), is(true));
+        assertThat(actual.getNextLearnDate(), is(actual.getLastLearnDate().plusDays(2)));
+        assertThat(actual.getIsDueForReview(), is(false));
+    }
+}


### PR DESCRIPTION
## Description of changes
Added two helper boolean fields if content has been learned yet and refined logic what "learned" actually means: must be success = true.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [x] automated unit test
- [x] automated integration test
- [ ] manual, exploratory test

    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
