### PR TITLE
Fixing the relationship between content and user progress data

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/ContentEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/ContentEntity.java
@@ -52,10 +52,6 @@ public class ContentEntity {
     @Builder.Default
     private ContentMetadataEmbeddable metadata = new ContentMetadataEmbeddable();
 
-    @Builder.Default
-    @Transient // todo remove
-    private List<UserProgressDataEntity> userProgressData = new ArrayList<>();
-
     public List<String> getTagNames() {
         return Optional.ofNullable(metadata.getTags())
                 .map(tags -> tags.stream().map(TagEntity::getName).toList())

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/ContentEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/ContentEntity.java
@@ -1,12 +1,9 @@
 package de.unistuttgart.iste.gits.content_service.persistence.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.DiscriminatorFormula;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -55,10 +52,8 @@ public class ContentEntity {
     @Builder.Default
     private ContentMetadataEmbeddable metadata = new ContentMetadataEmbeddable();
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "content_id")
     @Builder.Default
+    @Transient // todo remove
     private List<UserProgressDataEntity> userProgressData = new ArrayList<>();
 
     public List<String> getTagNames() {

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/UserProgressDataEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/entity/UserProgressDataEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OrderBy;
 
+import java.io.Serializable;
 import java.util.*;
 
 @Entity(name = "UserProgressData")
@@ -11,16 +12,15 @@ import java.util.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@IdClass(UserProgressDataEntity.UserProgressPk.class)
 public class UserProgressDataEntity {
 
+    @Column(name = "user_id", nullable = false)
     @Id
-    @GeneratedValue
-    private UUID id;
-
-    @Column(name = "user_id")
     private UUID userId;
 
-    @Column(name = "content_id")
+    @Column(name = "content_id", nullable = false)
+    @Id
     private UUID contentId;
 
     @ElementCollection
@@ -30,4 +30,9 @@ public class UserProgressDataEntity {
 
     @Column(nullable = true)
     private Integer learningInterval;
+
+    public static final class UserProgressPk implements Serializable {
+        private UUID userId;
+        private UUID contentId;
+    }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/repository/UserProgressDataRepository.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/persistence/repository/UserProgressDataRepository.java
@@ -12,4 +12,5 @@ public interface UserProgressDataRepository extends JpaRepository<UserProgressDa
 
     Optional<UserProgressDataEntity> findByUserIdAndContentId(UUID userId, UUID contentId);
 
+    void deleteByContentId(UUID id);
 }

--- a/src/main/java/de/unistuttgart/iste/gits/content_service/service/ContentService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/content_service/service/ContentService.java
@@ -7,8 +7,7 @@ import de.unistuttgart.iste.gits.content_service.dapr.TopicPublisher;
 import de.unistuttgart.iste.gits.content_service.persistence.entity.ContentEntity;
 import de.unistuttgart.iste.gits.content_service.persistence.entity.TagEntity;
 import de.unistuttgart.iste.gits.content_service.persistence.mapper.ContentMapper;
-import de.unistuttgart.iste.gits.content_service.persistence.repository.ContentRepository;
-import de.unistuttgart.iste.gits.content_service.persistence.repository.TagRepository;
+import de.unistuttgart.iste.gits.content_service.persistence.repository.*;
 import de.unistuttgart.iste.gits.content_service.validation.ContentValidator;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import jakarta.persistence.EntityNotFoundException;
@@ -25,6 +24,7 @@ import java.util.stream.Collectors;
 public class ContentService {
 
     private final ContentRepository contentRepository;
+    private final UserProgressDataRepository userProgressDataRepository;
     private final TagRepository tagRepository;
     private final StageService stageService;
     private final ContentMapper contentMapper;
@@ -360,7 +360,7 @@ public class ContentService {
      * @return the ID of the deleted content entity
      */
     private UUID removeContentDependencies(ContentEntity contentEntity) {
-
+        userProgressDataRepository.deleteByContentId(contentEntity.getId());
         // remove content from sections
         stageService.deleteContentLinksFromStages(contentEntity);
 

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/api/mutation/MutationDeleteContentTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/api/mutation/MutationDeleteContentTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 
-
 @ContextConfiguration(classes = MockTopicPublisherConfiguration.class)
 @GraphQlApiTest
 @TablesToDelete({"content_tags", "user_progress_data", "content", "tag"})
@@ -51,20 +50,25 @@ class MutationDeleteContentTest {
     void testDeleteExistingContent(GraphQlTester graphQlTester) {
         ContentEntity contentEntity = contentRepository.save(TestData.dummyAssessmentEntityBuilder()
                 .metadata(TestData.dummyContentMetadataEmbeddableBuilder()
-                        .tags(Set.of(
+                        .tags(new HashSet<>(Set.of(
                                 TagEntity.fromName("Tag"),
-                                TagEntity.fromName("Tag2")))
+                                TagEntity.fromName("Tag2"))))
                         .build())
-                .userProgressData(List.of(
-                        UserProgressDataEntity.builder()
-                                .userId(UUID.randomUUID())
-                                .learningInterval(2)
-                                .build(),
-                        UserProgressDataEntity.builder()
-                                .userId(UUID.randomUUID())
-                                .learningInterval(1)
-                                .build()))
+                .userProgressData(new ArrayList<>())
                 .build());
+
+        contentEntity.setUserProgressData(new ArrayList<>(List.of(
+                UserProgressDataEntity.builder()
+                        .contentId(contentEntity.getId())
+                        .userId(UUID.randomUUID())
+                        .learningInterval(2)
+                        .build(),
+                UserProgressDataEntity.builder()
+                        .contentId(contentEntity.getId())
+                        .userId(UUID.randomUUID())
+                        .learningInterval(1)
+                        .build())));
+        contentEntity = contentRepository.save(contentEntity);
 
         String query = """
                 mutation($id: UUID!) {
@@ -85,7 +89,6 @@ class MutationDeleteContentTest {
         assertThat(tagRepository.count(), is(0L));
 
     }
-
 
 
     /**

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/mapper/TestUserProgressDataMapper.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/mapper/TestUserProgressDataMapper.java
@@ -22,7 +22,6 @@ class TestUserProgressDataMapper {
     void testFullMapping() {
         UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
                 .userId(UUID.randomUUID())
-                .id(UUID.randomUUID())
                 .contentId(UUID.randomUUID())
                 .learningInterval(2)
                 .progressLog(List.of(
@@ -57,7 +56,6 @@ class TestUserProgressDataMapper {
     void testContentNotLearnedSuccessful() {
         UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
                 .userId(UUID.randomUUID())
-                .id(UUID.randomUUID())
                 .contentId(UUID.randomUUID())
                 .learningInterval(2)
                 .progressLog(List.of(
@@ -81,7 +79,6 @@ class TestUserProgressDataMapper {
     void testContentNotLearnedYet() {
         UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
                 .userId(UUID.randomUUID())
-                .id(UUID.randomUUID())
                 .contentId(UUID.randomUUID())
                 .learningInterval(2).build();
 
@@ -97,7 +94,6 @@ class TestUserProgressDataMapper {
     void testContentNotDueForRepetitionYet() {
         UserProgressDataEntity userProgressDataEntity = UserProgressDataEntity.builder()
                 .userId(UUID.randomUUID())
-                .id(UUID.randomUUID())
                 .contentId(UUID.randomUUID())
                 .learningInterval(2)
                 .progressLog(List.of(

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/service/ContentServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/service/ContentServiceTest.java
@@ -7,6 +7,7 @@ import de.unistuttgart.iste.gits.content_service.persistence.entity.ContentMetad
 import de.unistuttgart.iste.gits.content_service.persistence.mapper.ContentMapper;
 import de.unistuttgart.iste.gits.content_service.persistence.repository.ContentRepository;
 import de.unistuttgart.iste.gits.content_service.persistence.repository.TagRepository;
+import de.unistuttgart.iste.gits.content_service.persistence.repository.UserProgressDataRepository;
 import de.unistuttgart.iste.gits.content_service.test_config.MockTopicPublisherConfiguration;
 import de.unistuttgart.iste.gits.content_service.validation.ContentValidator;
 import de.unistuttgart.iste.gits.generated.dto.ContentType;
@@ -32,8 +33,10 @@ class ContentServiceTest {
     private final ContentValidator contentValidator = Mockito.spy(ContentValidator.class);
     private final TagService tagService = Mockito.mock(TagService.class);
     private final TopicPublisher mockPublisher = Mockito.mock(TopicPublisher.class);
+    private final UserProgressDataRepository userProgressDataRepository = Mockito.mock(UserProgressDataRepository.class);
 
-    private final ContentService contentService = new ContentService(contentRepository, null, tagRepository, stageService, contentMapper, contentValidator, tagService, mockPublisher);
+    private final ContentService contentService = new ContentService(contentRepository, userProgressDataRepository,
+            tagRepository, stageService, contentMapper, contentValidator, tagService, mockPublisher);
 
     @Test
     void forwardResourceUpdates() {
@@ -133,9 +136,12 @@ class ContentServiceTest {
         //execute method under test
         contentService.cascadeContentDeletion(dto);
 
-        verify(contentRepository, times(2)).delete(any(ContentEntity.class));
+        verify(contentRepository, times(1)).delete(argThat(content -> content.getId().equals(testEntity.getId())));
+        verify(contentRepository, times(1)).delete(argThat(content -> content.getId().equals(testEntity2.getId())));
         verify(mockPublisher, times(2)).notifyChange(any(ContentEntity.class), eq(CrudOperation.DELETE));
         verify(mockPublisher, times(1)).informContentDependentServices(List.of(testEntity.getId(), testEntity2.getId()), CrudOperation.DELETE);
+        verify(userProgressDataRepository, times(1)).deleteByContentId(argThat(content -> content.equals(testEntity.getId())));
+        verify(userProgressDataRepository, times(1)).deleteByContentId(argThat(content -> content.equals(testEntity2.getId())));
     }
 
     @Test

--- a/src/test/java/de/unistuttgart/iste/gits/content_service/service/ContentServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/content_service/service/ContentServiceTest.java
@@ -33,7 +33,7 @@ class ContentServiceTest {
     private final TagService tagService = Mockito.mock(TagService.class);
     private final TopicPublisher mockPublisher = Mockito.mock(TopicPublisher.class);
 
-    private final ContentService contentService = new ContentService(contentRepository, tagRepository, stageService, contentMapper, contentValidator, tagService, mockPublisher);
+    private final ContentService contentService = new ContentService(contentRepository, null, tagRepository, stageService, contentMapper, contentValidator, tagService, mockPublisher);
 
     @Test
     void forwardResourceUpdates() {


### PR DESCRIPTION
## Description of changes
Relationship between content entity and user progress data entity wasn't set correctly in the db. Remove the automatic mapping in the entities (we weren't using it anyways) and rely on manually storing user progress data in its repository.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [x] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

In case of manual test, please document the test well including a set of user instructions and prerequisites. Each including an action, it's result, and where appropriate a screenshot.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
